### PR TITLE
Update to version 1.2.1

### DIFF
--- a/R/geom-boxplot2.R
+++ b/R/geom-boxplot2.R
@@ -39,11 +39,9 @@
 #'   function.
 #' @inheritParams ggplot2::layer
 #' @inheritParams ggplot2::geom_bar
+#' @inheritParams geom_crossbar2
 #' @param geom,stat Use to override the default connection between
 #'   \code{geom_boxplot2} and \code{stat_boxplot2}.
-#' @param median_symbol a logical value indicating whether to use a symbol
-#'   (\code{TRUE}) or a line (\code{FALSE}) to represent the median when a color
-#'   aesthetic is used.
 #' @param outlier.position
 #'   By default, outliers are displayed with a small degree of jitter. Sometimes
 #'   it can be useful to hide the outliers, for example when overlaying the raw
@@ -347,13 +345,20 @@ GeomBoxplot2 <- ggplot2::ggproto(
     # if there is a color aesthetic and median_symbol is TRUE, represent the
     # median with the corresponding symbol and color. otherwise, represent the
     # median with a line segment.
-    if ( length(data$ncolours) > 0 && isTRUE(median_symbol) ){
+    if ( length(data$ncolours) > 0 ){
       ggplot2:::ggname(
         "geom_boxplot2",
         grid::grobTree(
           outliers_grob,
           ggplot2::GeomSegment$draw_panel(whiskers, panel_params, coord),
-          GeomCrossbar2$draw_panel(box, fatten = fatten, panel_params, coord, flipped_aes = flipped_aes)
+          GeomCrossbar2$draw_panel(
+            box,
+            median_symbol = median_symbol,
+            fatten = fatten,
+            panel_params,
+            coord,
+            flipped_aes = flipped_aes
+          )
         )
       )
     } else {
@@ -362,7 +367,13 @@ GeomBoxplot2 <- ggplot2::ggproto(
         grid::grobTree(
           outliers_grob,
           ggplot2::GeomSegment$draw_panel(whiskers, panel_params, coord),
-          ggplot2::GeomCrossbar$draw_panel(box, fatten = fatten, panel_params, coord, flipped_aes = flipped_aes)
+          ggplot2::GeomCrossbar$draw_panel(
+            box,
+            fatten = fatten,
+            panel_params,
+            coord,
+            flipped_aes = flipped_aes
+          )
         )
       )
     }

--- a/man/geom_crossbar2.Rd
+++ b/man/geom_crossbar2.Rd
@@ -10,6 +10,7 @@ geom_crossbar2(
   stat = "identity",
   position = "identity",
   ...,
+  median_symbol = TRUE,
   fatten = 2.5,
   na.rm = FALSE,
   orientation = NA,
@@ -52,6 +53,10 @@ settings of the adjustment.}
 often aesthetics, used to set an aesthetic to a fixed value, like
 \code{colour = "red"} or \code{size = 3}. They may also be parameters
 to the paired geom/stat.}
+
+\item{median_symbol}{a logical value indicating whether to use a symbol
+(\code{TRUE}) or a line (\code{FALSE}) to represent the median when a color
+aesthetic is used.}
 
 \item{fatten}{A multiplicative factor used to increase the size of the
 middle bar in \code{\link[ggplot2]{geom_crossbar}} and the middle point in


### PR DESCRIPTION
(copied from NEWS.md)

# ggcognigen 1.2.1

* Added `median_symbol` argument to `geom_boxplot2` to allow for a median line to be used instead of the symbol.
* Updates based on changes to dependencies ggplot2 and flextable.
* Fix height in `get_device_size` for 3 plot per page layout.
* Fix bug in `make_gmr_data` where invalid rows are removed.